### PR TITLE
Adding Reference Architectures to Ansible Deck Finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ href="https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_p
 <tr>
 <td>Deploying Ansible Automation Platform 2 on Red Hat OpenShift</td>
 <td><a target="_blank"
-href="https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/deploying_ansible_automation_platform_2_on_red_hat_openshift/index>Link</a></td>
+href="https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/deploying_ansible_automation_platform_2_on_red_hat_openshift/index">Link</a></td>
 </tr>
 <tr>
 <td>Ansible Automation Platform 1.2 to 2 Migration Guide</td>

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [Infrastructure Automation](#infrastructure-automation)
 - [Security Automation](#security-automation)
 - [ServiceNow ITSM Automation](#servicenow-itsm-automation)
+- [Reference Architectures](#reference-architectures)
 
 </div>
 <div class='highlighttable'>

--- a/README.md
+++ b/README.md
@@ -513,3 +513,31 @@ and <a target="_blank" href="https://docs.google.com/presentation/d/1LnGlQvdL27E
 </tr>
 </tbody>
 </table>
+
+# Reference Architectures
+
+<table>
+<thead>
+<tr>
+<th>Reference Architecture</th>
+<th>Red Hat Link</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Deploying Ansible Automation Platform 2.1</td>
+<td><a target="_blank"
+href="https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html-single/deploying_ansible_automation_platform_2.1/index">Link</a></td>
+</tr>
+<tr>
+<td>Deploying Ansible Automation Platform 2 on Red Hat OpenShift</td>
+<td><a target="_blank"
+href="https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/deploying_ansible_automation_platform_2_on_red_hat_openshift/index>Link</a></td>
+</tr>
+<tr>
+<td>Ansible Automation Platform 1.2 to 2 Migration Guide</td>
+<td><a target="_blank"
+href="https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/ansible_automation_platform_1.2_to_2_migration_guide/index">Link</a></td>
+</tr>
+</tbody>
+</table>


### PR DESCRIPTION
Want to make it easier to find our reference architectures. This PR includes the 3 Ref Archs we have in our product documentation 