### PR TITLE
Remove IDC Built ROI Calculator link

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,12 +183,6 @@
 </thead>
 <tbody>
 <tr>
-<td>IDC Built ROI Calculator:
-Identify and calculate the Business Value and Impact of IT Automation with AAP</td>
-<td><a target="_blank" href="https://docs.google.com/presentation/d/1-Z2ZT6gg5pPlo9kpmNLf5tnkPOqHfpxRn-zCgtyE7oY/edit?usp=sharing">Google Source</a></td>
-<td><a target="_blank" href="https://redhatansibleroi.com/">https://redhatansibleroi.com/</a></td>
-</tr>
-<tr>
 <td>Simple Ansible Time/Cost Saving Tool:
 Use the Red Hat portal tooling to determine high level time and cost savings</td>
 <td><a target="_blank" href="https://docs.google.com/presentation/d/1LnGlQvdL27EOl6Ym_hIiqPaubzIZ1z7cCkvamm8gn5E/edit?usp=sharing">Google Source</a></td>


### PR DESCRIPTION
## Summary
This PR removes the IDC Built ROI Calculator link from the ROI section as the service is not being renewed.

## Changes
- Removed the "IDC Built ROI Calculator" entry from the ROI (Return on Investment) section
- Removed associated links to https://redhatansibleroi.com/ and Google Source

## Reason
The IDC Built ROI Calculator service is not being renewed, so the link should be removed from the slide finder to avoid directing users to a service that will no longer be available.

Made with [Cursor](https://cursor.com)