### PR TITLE
Add AAP 2.7 to Release section and update Power 5 episodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,11 @@ Use the Red Hat portal tooling to determine high level time and cost savings</td
 </thead>
 <tbody>
 <tr>
+<td>AAP 2.7 Overview (May 7, 2026)</td>
+<td><a target="_blank" href="https://docs.google.com/presentation/d/1x01wBxJ5gKrya4QxDDWUGldkM0rNYrv0CcnZmtTO0sU/edit?usp=sharing">Google Source</a></td>
+<td>Coming soon!</td>
+</tr>
+<tr>
 <td>AAP 2.5 Overview (Sep 30, 2024)</td>
 <td><a target="_blank" href="https://docs.google.com/presentation/d/1mM0lfsQYy4d0TG4jHMpjElTDuPkdrqfJMhVBOKIyqqc/edit?usp=sharing">Google Source</a></td>
 <td><a target="_blank" href="https://content.redhat.com/us/en/assets/display.html?id=4ce94e30-a744-43b2-aad7-c802b0a30a9b">Content Center</a></td>

--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@
 </thead>
 <tbody>
 <tr>
+<td><a target="_new" href="https://videos.learning.redhat.com/media/Power%205%20-%20Episode%2068%20%22Master%20your%20AAP%202_7%20Pitch%22/1_5soe6g6j/366567272">Power 5 - Episode 68 "Master your AAP 2.7 Pitch"</a></td>
+<td>Tricia McConnell</td>
+<td>June 17th, 2026</td>
+</tr>
+<tr>
 <td><a target="_new" href="https://videos.learning.redhat.com/media/1_4pszx8k5">Power 5 - Episode 66 "Ansible Automation Platform + MetLife Win"</a></td>
 <td>Harper Buete and Tucker Fisher</td>
 <td>May 7th, 2026</td>
-</tr>
-<tr>
-<td><a target="_new" href="https://videos.learning.redhat.com/media/1_sfku6h6j">Power 5 - Episode 56 "Unlocking Revenue - The sellers guide to AAP Metrics utility and host consulting"</a></td>
-<td>Courtney Cydylo</td>
-<td>March 12th, 2026</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
## Summary
This PR adds the AAP 2.7 deck to the Release information section and updates the Power 5 episodes with the latest content.

## Changes

### Release Information Section
- Added **AAP 2.7 Overview (May 7, 2026)** to the Release information section
- Links to the same Google Slides deck already featured in the top news section
- Content Center link set as "Coming soon!" pending publication

### Power 5 Section Update
- **Added:** Episode 68 "Master your AAP 2.7 Pitch" (Tricia McConnell, June 17th, 2026)
- **Removed:** Episode 56 "Unlocking Revenue" (March 12th, 2026) - keeping only the 2 most recent episodes

### Current Power 5 Episodes
1. Episode 68 - "Master your AAP 2.7 Pitch" - Tricia McConnell (June 17th, 2026)
2. Episode 66 - "Ansible Automation Platform + MetLife Win" - Harper Buete and Tucker Fisher (May 7th, 2026)

All changes maintain consistency with existing format and structure.

Made with [Cursor](https://cursor.com)